### PR TITLE
Replacing gruel/attributes.h with

### DIFF
--- a/include/mediatools_api.h
+++ b/include/mediatools_api.h
@@ -22,7 +22,7 @@
 #ifndef INCLUDED_MEDIATOOLS_API_H
 #define INCLUDED_MEDIATOOLS_API_H
 
-#include <gruel/attributes.h>
+#include <gnuradio/attributes.h>
 
 #ifdef gnuradio_mediatools_EXPORTS
 #  define MEDIATOOLS_API __GR_ATTR_EXPORT


### PR DESCRIPTION
gnuradio/attributes.h for v3.7 compatibility.
