### PR TITLE
close av context in block dtor

### DIFF
--- a/include/mediatools_audiosource_impl.h
+++ b/include/mediatools_audiosource_impl.h
@@ -25,6 +25,7 @@ class mediatools_audiosource_impl {
 
         mediatools_audiosource_impl();
         bool open(std::string);
+        void close();
         void readData(std::vector<int16_t> &r);
     
         AVFormatContext* d_format_ctx;

--- a/lib/mediatools_audiosource_impl.cc
+++ b/lib/mediatools_audiosource_impl.cc
@@ -76,6 +76,11 @@ bool mediatools_audiosource_impl::open(std::string filename){
      
 }
 
+void mediatools_audiosource_impl::close() {
+    // Also frees the context
+    avformat_close_input(&d_format_ctx);
+}
+
 void mediatools_audiosource_impl::readData(std::vector<int16_t> &r){
     // set up packet
     av_init_packet(&d_packet);

--- a/lib/mediatools_audiosource_s.cc
+++ b/lib/mediatools_audiosource_s.cc
@@ -50,6 +50,7 @@ mediatools_audiosource_s::mediatools_audiosource_s (std::vector<std::string> arg
 
 mediatools_audiosource_s::~mediatools_audiosource_s ()
 {
+    d_impl->close();
 }
 
 #define EXIT_ON_LIST_END    false
@@ -81,13 +82,13 @@ mediatools_audiosource_s::work (int noutput_items,
                     return noutput_items;
                 }
             }
-        d_impl->open(d_list[0]);
-        d_list.erase(d_list.begin(), d_list.begin()+1);
-    }
+            d_impl->open(d_list[0]);
+            d_list.erase(d_list.begin(), d_list.begin()+1);
+        }
 
-    // decode more data
-    d_impl->readData(d_data);
-  }
+        // decode more data
+        d_impl->readData(d_data);
+    }
 
   // generate stream tags with media metadata
   typedef std::map<std::string,std::string>::value_type metaitemtype;
@@ -107,7 +108,8 @@ mediatools_audiosource_s::work (int noutput_items,
     message_port_pub(pmt::mp("change"), msg);
     }
 
-  // copy data to our output buffer
+
+    // copy data to our output buffer
   memcpy(out, &d_data[0], noutput_items*sizeof(int16_t));
   d_data.erase(d_data.begin(), d_data.begin()+noutput_items);
   return noutput_items;


### PR DESCRIPTION
There's currently some FD leakage if the thread shuts down but process
lives. It's possible that some other close() calls would be appropriate
when handling errors in the impl, but this solves current issues

![image](https://cloud.githubusercontent.com/assets/1879306/18065727/2ffb2808-6e03-11e6-9209-fe80e8d7a9f8.png)
