### PR TITLE
fix to ensure use of python2 not python3

### DIFF
--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -21,7 +21,7 @@
 # Include swig generation macros
 ########################################################################
 find_package(SWIG)
-find_package(PythonLibs)
+find_package(PythonLibs 2)
 if(NOT SWIG_FOUND OR NOT PYTHONLIBS_FOUND)
     return()
 endif()


### PR DESCRIPTION
Setting this up on my system running ubuntu 16.04 I was encountering issues with SWIG, noticed it was linking in python3.5 library. I changed this to force it to use python2, it appeared to work for me. Not sure its a necessary for all setups (I am running locally not using docker).
